### PR TITLE
Add base structure for the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# A SOLID implementatio in Rust
+# A SOLID implementation in Rust

--- a/solid_cli/Cargo.toml
+++ b/solid_cli/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Florian Fromm <flrn.frmm@gmail.com>", "Sebastian Heusser <huhn@einfachiota.de>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "solid-rs"
+path = "src/main.rs"
 
 [dependencies]
+clap = "2.33.3"

--- a/solid_cli/src/lib.rs
+++ b/solid_cli/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/solid_cli/src/main.rs
+++ b/solid_cli/src/main.rs
@@ -1,0 +1,38 @@
+use clap::{App, Arg, ArgMatches};
+
+fn main() {
+    let cli = App::new("solid-rs")
+        .version("0.1.0")
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(App::new("init")
+            .about("Setup routine to run a solid-rs server"))   
+        .subcommand(App::new("start")
+            .about("Start a solid-rs server instance")
+            .arg(Arg::with_name("port")
+                .short("p")
+                .long("port")
+                .value_name("PORT")
+                .help("Port the server will listen on")
+                .takes_value(true)))
+        .get_matches();
+    
+    match cli.subcommand() {
+        ("init", _) => init_server(),
+        ("start", optional_matches) => start_server(optional_matches), 
+        _   => { }
+    }
+}
+
+fn init_server() {
+    println!("Running setup wizard...")
+}
+
+fn start_server(optional_matches: Option<&ArgMatches>) {
+    let default_port = "80";
+    if let Some(matches) = optional_matches {
+        let port = matches.value_of("port").unwrap_or(default_port);
+        println!("Server start listening on port :{}", port)
+    } else {
+        println!("Server start listening on default port :{}", default_port)
+    }
+}


### PR DESCRIPTION
Similar to node-solid-server. 
Base structure for a CLI with two subcommands `init` and `start`.