### PR TITLE
Add functionality of init & start to cli

### DIFF
--- a/solid_cli/Cargo.toml
+++ b/solid_cli/Cargo.toml
@@ -9,4 +9,7 @@ name = "solid-rs"
 path = "src/main.rs"
 
 [dependencies]
+tokio = { version = "0.2", features = ["full"] }
+solid_server = { path = "../solid_server" }
+
 clap = "2.33.3"

--- a/solid_cli/src/initialize.rs
+++ b/solid_cli/src/initialize.rs
@@ -1,0 +1,45 @@
+use clap::ArgMatches;
+use std::{fs::{create_dir_all, File}, io::Write};
+use std::path::Path;
+
+use solid_server::configuration::Configuration;
+
+const DEFAULT_CONFIGURATION_PATH: &str = "./solid-rs-configuration.yaml";
+
+pub fn initialize_server_configuration(optional_matches: Option<&ArgMatches>) {
+    let configuration_path: &Path;
+
+    if let Some(matches) = optional_matches {
+        configuration_path = Path::new(matches.value_of("configuration")
+            .unwrap_or(DEFAULT_CONFIGURATION_PATH));
+    } else {
+        configuration_path = Path::new(DEFAULT_CONFIGURATION_PATH);
+    }
+
+    initialize_configuration_file(configuration_path);
+}
+
+fn initialize_configuration_file(configuration_path: &Path) {
+    if configuration_path.exists() {
+        println!("Configuration file {} already exists!", configuration_path.to_str().unwrap());
+    } else {
+        let configuration = run_setup_wizard();
+        println!("Saving configuration to {}", configuration_path.to_str().unwrap());
+        match create_dir_all(configuration_path.parent().unwrap()) {
+            Ok(()) => {
+                match File::create(configuration_path) {
+                    Ok(mut file) => file.write_all(&configuration.to_yaml().unwrap().into_bytes()).unwrap(),
+                    Err(error) => println!("Error: {}", error)
+                }
+            },
+            Err(error) =>  println!("Error: {}", error)
+        };
+    }
+}
+
+fn run_setup_wizard() -> Configuration {
+    let configuration = Configuration::new();
+    println!("Running setup wizard...");
+    // To be done !
+    configuration
+}

--- a/solid_cli/src/main.rs
+++ b/solid_cli/src/main.rs
@@ -1,38 +1,44 @@
-use clap::{App, Arg, ArgMatches};
+mod initialize;
+mod server;
+
+use clap::{App, Arg};
+
+use initialize::initialize_server_configuration;
+use server::start;
 
 fn main() {
     let cli = App::new("solid-rs")
         .version("0.1.0")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(App::new("init")
-            .about("Setup routine to run a solid-rs server"))   
-        .subcommand(App::new("start")
-            .about("Start a solid-rs server instance")
-            .arg(Arg::with_name("port")
-                .short("p")
-                .long("port")
-                .value_name("PORT")
-                .help("Port the server will listen on")
-                .takes_value(true)))
+        .subcommand(generate_init_subcommand())
+        .subcommand(generate_start_subcommand())
         .get_matches();
     
     match cli.subcommand() {
-        ("init", _) => init_server(),
-        ("start", optional_matches) => start_server(optional_matches), 
+        ("init", optional_matches) => initialize_server_configuration(optional_matches),
+        ("start", optional_matches) => start(optional_matches), 
         _   => { }
     }
 }
 
-fn init_server() {
-    println!("Running setup wizard...")
+fn generate_init_subcommand() -> App<'static, 'static> {
+    App::new("init")
+        .about("Setup routine to run a solid-rs server")   
+        .arg(Arg::with_name("configuration")
+            .short("c")
+            .long("configuration")
+            .value_name("PATH")
+            .help("Path to the configuration file")
+            .takes_value(true))
 }
 
-fn start_server(optional_matches: Option<&ArgMatches>) {
-    let default_port = "80";
-    if let Some(matches) = optional_matches {
-        let port = matches.value_of("port").unwrap_or(default_port);
-        println!("Server start listening on port :{}", port)
-    } else {
-        println!("Server start listening on default port :{}", default_port)
-    }
+fn generate_start_subcommand() -> App<'static, 'static> {
+    App::new("start")
+        .about("Start a solid-rs server instance")
+        .arg(Arg::with_name("port")
+            .short("p")
+            .long("port")
+            .value_name("PORT")
+            .help("Port the server will listen on")
+            .takes_value(true))
 }

--- a/solid_cli/src/server.rs
+++ b/solid_cli/src/server.rs
@@ -1,0 +1,36 @@
+use clap::ArgMatches;
+use tokio::runtime::Runtime;
+
+use solid_server::{start_server, configuration::Configuration};
+
+pub fn start(optional_matches: Option<&ArgMatches>) {
+    let mut configuration = load_server_configuration();
+
+    if let Some(matches) = optional_matches {
+        apply_cli_arguments(&mut configuration, matches);
+    }
+
+    match Runtime::new() {
+        Ok(mut runtime) => runtime.block_on(start_server(&configuration)),
+        Err(error) => println!("Error: {}", error)
+    }
+}
+
+fn load_server_configuration() -> Configuration {
+    /*  ToDo ... 
+    *   Load configuration from optional configuration file.
+    *   If it exists!
+    *   Else we take teh default values of Configuration::new()
+    */
+    Configuration::new()
+}
+
+fn apply_cli_arguments(configuration: &mut Configuration, matches: &ArgMatches) {
+    // Cli arguments override default & config file arguments
+    if let Some(val) = matches.value_of("port") {
+        match val.parse::<u16>() {
+            Ok(port) => configuration.port = port,
+            Err(error) => println!("Error: {}", error)
+        }
+    }
+}

--- a/solid_server/Cargo.toml
+++ b/solid_server/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 [dependencies]
 hyper = "0.13"
 tokio = { version = "0.2", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"

--- a/solid_server/src/configuration.rs
+++ b/solid_server/src/configuration.rs
@@ -1,3 +1,22 @@
+use serde::{Serialize, Deserialize};
+
+const DEFAULT_PORT: u16 = 8080;
+
+#[derive(Serialize, Deserialize)]
 pub struct Configuration {
     pub port: u16
+}
+
+impl Configuration {
+    pub fn new() -> Self {
+        Self { port: DEFAULT_PORT }
+    }
+
+    pub fn from_yaml(yaml_string: String) -> Result<Self, serde_yaml::Error> {
+        serde_yaml::from_str(&yaml_string)
+    }
+
+    pub fn to_yaml(&self) -> Result<String, serde_yaml::Error> {
+        serde_yaml::to_string(self)
+    }
 }

--- a/solid_server/src/lib.rs
+++ b/solid_server/src/lib.rs
@@ -1,12 +1,14 @@
-mod configuration;
+pub mod configuration;
 
 use std::convert::Infallible;
 use std::net::{SocketAddr, IpAddr, Ipv4Addr};
 use hyper::{Body, Request, Response, Server, Method, StatusCode};
 use hyper::service::{make_service_fn, service_fn};
 
-pub async fn start(config: configuration::Configuration) {
-    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), config.port);
+use configuration::Configuration;
+
+pub async fn start_server(configuration: &Configuration) {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), configuration.port);
 
     let solid_svc = make_service_fn(|_| async { Ok::<_,hyper::Error>(service_fn(serve_solid)) });
 


### PR DESCRIPTION
Subcommand `init` no creates a .yaml config file.
Subcommand `start` now starts a solid-server.